### PR TITLE
main: Bugfixes for BMC zip file creation

### DIFF
--- a/bmc-ver.go
+++ b/bmc-ver.go
@@ -31,9 +31,9 @@ type IMGINFO struct {
 
 var Images = [5]IMAGE{
 	{"ubo", "worktrees/u-boot/platina-mk1-bmc", "platina-mk1-bmc-ubo.bin"},
-	{"dtb", "worktrees/linux/platina-mk1-bmc", "platina-mk1-bmc.dtb"},
+	{"dtb", "worktrees/linux/platina-mk1-bmc", "platina-mk1-bmc-dtb.bin"},
 	{"env", ".", "platina-mk1-bmc-env.bin"},
-	{"ker", "worktrees/linux/platina-mk1-bmc", "platina-mk1-bmc.vmlinuz"},
+	{"ker", "worktrees/linux/platina-mk1-bmc", "platina-mk1-bmc-ker.bin"},
 	{"ini", "../goes-bmc", "platina-mk1-bmc-ini.bin"},
 }
 var ImgInfo [5]IMGINFO


### PR DESCRIPTION
Fix missing kernel build and build the proper bmc image instead
of the boot image. Also build the dts file using the -dtb.bin suffix
instead of .dtb so the installer will find it.

Signed-off-by: Kevin Paul Herbert <kph@platinasystems.com>