### PR TITLE
u-boot: Pick up proper image now that we use device tree

### DIFF
--- a/main.go
+++ b/main.go
@@ -309,7 +309,7 @@ func makeArmBoot(out, name string) (err error) {
 		return err
 	}
 
-	uboot := makeUboot("worktrees/u-boot/" + machine + "/u-boot.imx")
+	uboot := makeUboot("worktrees/u-boot/" + machine + "/u-boot-dtb.imx")
 	if err = ioutil.WriteFile(machine+"-ubo.bin", uboot, 0644); err != nil {
 		return err
 	}


### PR DESCRIPTION
U-boot now uses the device tree. The generated file is now
u-boot-dtb.imx. Pick this up to create the zip archive.

Signed-off-by: Kevin Paul Herbert <kph@platinasystems.com>